### PR TITLE
[MM-59504] add binary release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Tag Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: The version of the release tag.
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Tag release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/${{ inputs.version }}',
+            sha: context.sha
+            })
+      - name: Checkout project
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        with:
+          distribution: goreleaser
+          version: ${{ inputs.version }}
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ migrations
 postgres
 mysql
 diffs
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,38 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/migration-assist
+    id: "migration-assist"
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/mattermost/migration-assist/cmd/migration-assist/commands.Version={{.Version}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}-{{- title .Os }}-{{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+changelog:
+  sort: desc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: mattermost
+    name: migration-assist
+  name_template: "{{ .ProjectName }}-v{{ .Version }}"
+  disable: false

--- a/cmd/migration-assist/commands/version.go
+++ b/cmd/migration-assist/commands/version.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version = "dev"
+)
+
+func VersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version of migration-assist.",
+		RunE:  versionCmdF,
+	}
+}
+
+func versionCmdF(cmd *cobra.Command, _ []string) error {
+	v, err := getVersionInfo()
+	if err != nil {
+		return err
+	}
+
+	cmd.Printf("migration-assist:\nVersion:\t%s\n"+
+		"CommitDate:\t%s\nGitCommit:\t%s\nGitTreeState:\t%s\nGoVersion:\t%s\n"+
+		"Compiler:\t%s\nPlatform:\t%s\n",
+		Version, v.CommitDate, v.GitCommit, v.GitTreeState, v.GoVersion, v.Compiler, v.Platform)
+	return nil
+}
+
+type Info struct {
+	CommitDate   string
+	GitCommit    string
+	GitTreeState string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func getVersionInfo() (*Info, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, errors.New("failed to get build info")
+	}
+
+	var (
+		revision     = "dev"
+		gitTreeState = "dev"
+		commitDate   = "dev"
+
+		os       string
+		arch     string
+		compiler string
+	)
+
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.time":
+			commitDate = s.Value
+		case "vcs.modified":
+			if s.Value == "true" {
+				gitTreeState = "dirty"
+			} else {
+				gitTreeState = "clean"
+			}
+		case "GOOS":
+			os = s.Value
+		case "GOARCH":
+			arch = s.Value
+		case "-compiler":
+			compiler = s.Value
+		}
+	}
+
+	return &Info{
+		CommitDate:   commitDate,
+		GitCommit:    revision,
+		GitTreeState: gitTreeState,
+		GoVersion:    info.GoVersion,
+		Compiler:     compiler,
+		Platform:     fmt.Sprintf("%s/%s", arch, os),
+	}, nil
+}

--- a/cmd/migration-assist/main.go
+++ b/cmd/migration-assist/main.go
@@ -26,6 +26,7 @@ func main() {
 		commands.SourceCheckCmd(),
 		commands.TargetCheckCmd(),
 		commands.GeneratePgloaderConfigCmd(),
+		commands.VersionCmd(),
 	)
 
 	if err := root.Execute(); err != nil {


### PR DESCRIPTION

#### Summary
Add release workflow to create binary release from the repository page. Also added a `version` subcommand to keep track of the versions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59504
