### PR TITLE
Updates for flag values and add a informative error message

### DIFF
--- a/cmd/migration-assist/commands/pgloader.go
+++ b/cmd/migration-assist/commands/pgloader.go
@@ -28,7 +28,7 @@ func GeneratePgloaderConfigCmd() *cobra.Command {
 
 	// Optional flags
 	cmd.PersistentFlags().String("output", "", "The filename of the generated configuration")
-	cmd.PersistentFlags().Bool("remove-null-chars", false, "Adds transformations to remove null characters on the fly")
+	cmd.PersistentFlags().Bool("remove-null-chars", true, "Adds transformations to remove null characters on the fly")
 	return cmd
 }
 


### PR DESCRIPTION


#### Summary
A few lessons from a migration story, we can set `remove-null-chars` flag to be `true` to avoid failures, and also be more informative on failures during the index creation.

