### PR TITLE
[MM-58713] Add docker compose and the workflow for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,60 @@
+name: Integration Test
+on:
+  push:
+    branches:
+      - MM-58713
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    env:
+      MYSQL_DSN: mmuser:mostest@tcp(localhost:3606)/mattermost_test
+      PGSQL_DSN: postgres://mmuser:mostest@localhost:8432/mattermost_test?sslmode=disable
+      MM_VERSION: v9.11
+    steps:
+      - name: Checkout migration-assist project
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Calculate Golang Version
+        id: go
+        run: echo GO_VERSION=$(sed -n '3p' go.mod | awk '{print $2}') >> "${GITHUB_OUTPUT}"
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ steps.go.outputs.GO_VERSION }}
+      - name: Run docker compose
+        run: |
+          cd build
+          docker compose --ansi never run --rm start_dependencies
+          docker compose --ansi never exec -T mattermost sh -c 'bin/mmctl sampledata -u 60 --local';
+          docker compose --ansi never ps
+      - name: Fix MySQL user permissions
+        run: |
+          cd build
+          docker compose exec mysql sh -c "sed -i '/# default-authentication-plugin/c\default-authentication-plugin=mysql_native_password' /etc/my.cnf"
+          docker compose exec mysql sh -c "mysql -u root -pmostest -e \"ALTER USER 'mmuser'@'%' IDENTIFIED WITH mysql_native_password BY 'mostest';\""
+          docker compose exec mysql sh -c "mysql -u root -pmostest -e \"ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'mostest';\""
+          docker compose restart mysql && sleep 10
+      - name: Build migration-assist
+        run: |
+          go install ./cmd/migration-assist/
+      - name: Run migration-assist mysql
+        run: migration-assist mysql $MYSQL_DSN --fix-unicode --fix-artifacts --fix-varchar
+      - name: Run migration-assist postgres
+        run: migration-assist postgres $PGSQL_DSN --run-migrations --mattermost-version=$MM_VERSION
+      - name: Run migration-assist pgloader
+        run: |
+          migration-assist pgloader --mysql $MYSQL_DSN --postgres $PGSQL_DSN > migration.load
+      - name: Run pgloader
+        run: |
+          docker run --rm -v $(pwd):/home/migration --network="host" mattermost/mattermost-pgloader pgloader migration.load > migration.log
+      - name: Stop docker compose
+        run: |
+          cd build
+          docker compose --ansi never stop
+      - name: Persist test artifacts
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: test-artifact
+          path: |
+            migration.load
+            migration.log

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,71 @@
+version: "2.4"
+services:
+  mysql:
+    image: "mysql/mysql-server:8.0.32"
+    restart: always
+    networks:
+      - ma-test
+    ports:
+      - "3606:3306"
+    environment:
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ROOT_PASSWORD: mostest
+      MYSQL_PASSWORD: mostest
+      MYSQL_USER: mmuser
+      MYSQL_DATABASE: mattermost_test
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - ./docker/mysql.conf.d/source.cnf:/etc/mysql/conf.d/mysql.cnf
+  postgres:
+    image: "postgres:11"
+    restart: always
+    networks:
+      - ma-test
+    ports:
+      - "8432:5432"
+    environment:
+      POSTGRES_USER: mmuser
+      POSTGRES_PASSWORD: mostest
+      POSTGRES_DB: mattermost_test
+    command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
+    volumes:
+      - "./docker/postgres.conf:/etc/postgresql/postgresql.conf"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "mmuser", "-d", "mattermost_test"]
+      interval: 5s
+      timeout: 10s
+      retries: 3
+  mattermost:
+    image: mattermost/mattermost-team-edition:9.11.0
+    restart: always
+    networks:
+      - ma-test
+    ports:
+      - "8088:8065"
+    depends_on:
+      - mysql
+      - postgres
+    environment:
+      MM_SERVICESETTINGS_ENABLELOCALMODE: "true"
+      MM_SERVICESETTINGS_SITEURL: "http://localhost:8065"
+      MM_SERVICESETTINGS_LISTENADDRESS: ":8065"
+      MM_SQLSETTINGS_DRIVERNAME: "mysql"
+      MM_SQLSETTINGS_DATASOURCE: "mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+      MM_TEAMSETTINGS_MAXUSERSPERTEAM: "100"
+  start_dependencies:
+    image: mattermost/mattermost-wait-for-dep:latest
+    networks:
+      - ma-test
+    depends_on:
+      - mysql
+      - postgres
+      - mattermost
+    command: mysql:3306 postgres:5432 mattermost:8065
+
+networks:
+  ma-test:
+    driver: bridge

--- a/build/docker/mysql.conf.d/custom.cnf
+++ b/build/docker/mysql.conf.d/custom.cnf
@@ -1,0 +1,20 @@
+[mysqld]
+bind-address = 0.0.0.0
+
+default-authentication-plugin=mysql_native_password
+log-output = NONE
+slow-query-log = 0
+innodb_flush_log_at_trx_commit = 2
+innodb_flush_method = nosync
+innodb_lock_wait_timeout = 50
+innodb_log_buffer_size = 3M
+innodb_buffer_pool_size = 180M
+
+max_connect_errors = 1000000
+max_connections = 900
+
+character-set-server = utf8
+sql_mode = ""
+innodb = FORCE
+default-storage-engine = Memory
+max_allowed_packet = 256M

--- a/build/docker/mysql.conf.d/source.cnf
+++ b/build/docker/mysql.conf.d/source.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+
+server-id = 1
+log-bin = mysql-bin

--- a/build/docker/postgres.conf
+++ b/build/docker/postgres.conf
@@ -1,0 +1,7 @@
+max_connections = 300
+listen_addresses = '*'
+fsync = off
+full_page_writes = off
+default_text_search_config = 'pg_catalog.english'
+commit_delay=1000
+logging_collector=off


### PR DESCRIPTION

#### Summary
We basically spin up a MySQL, Postgres and Mattermost instances to emulate real world deployment to run `migration-assist` against.
- The `build/docker-compose.yml` is to make sure that environment is ready for the tests.
- The new "Integration Test" action runs several `migraiton-assist` commands
  - `mysql` with fix flags
  - `postgres` with mattermost version, downloads the migrations and applies them
  - `pgloader` generates the configuration files
- We indeed run `pgloader` itself with Docker (to cover the guide) to run and test the configuration and migrate the data
- The action saves the outputs (eg, `.load` file and `log` files for further processing and debugging).

This was the cherry on the top to ensure the tool has a quality control and after this we can go `v0.1`. 

For the future iterations:
- We can include plugin migrations
- Run some SQL queries to break MySQL database to make use of fixes in the `mysql` subcommand of `migraiton-assist`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58713

