### PR TITLE
Simplify unicode fixes by removing the check for the column

### DIFF
--- a/queries/fixes/unicode/fix_channelmembers_notifyprops.sql
+++ b/queries/fixes/unicode/fix_channelmembers_notifyprops.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'ChannelMembers'
-     AND table_schema = DATABASE()
-     AND column_name = 'NotifyProps'
- ) > 0,
- 'UPDATE ChannelMembers SET NotifyProps = REPLACE(NotifyProps, \'\\\\u0000\', \'\') WHERE NotifyProps LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE ChannelMembers SET NotifyProps = REPLACE(NotifyProps, '\u0000', '') WHERE NotifyProps LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_jobs_data.sql
+++ b/queries/fixes/unicode/fix_jobs_data.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Jobs'
-     AND table_schema = DATABASE()
-     AND column_name = 'Data'
- ) > 0,
- 'UPDATE Jobs SET Data = REPLACE(Data, \'\\\\u0000\', \'\') WHERE Data LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Jobs SET Data = REPLACE(Data, '\u0000', '') WHERE Data LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_linkmetadata_data.sql
+++ b/queries/fixes/unicode/fix_linkmetadata_data.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'LinkMetadata'
-     AND table_schema = DATABASE()
-     AND column_name = 'Data'
- ) > 0,
- 'UPDATE LinkMetadata SET Data = REPLACE(Data, \'\\\\u0000\', \'\') WHERE Data LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE LinkMetadata SET Data = REPLACE(Data, '\u0000', '') WHERE Data LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_posts.props.sql
+++ b/queries/fixes/unicode/fix_posts.props.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Posts'
-     AND table_schema = DATABASE()
-     AND column_name = 'Props'
- ) > 0,
- 'UPDATE Posts SET Props = REPLACE(Props, \'\\\\u0000\', \'\') WHERE Props LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Posts SET Props = REPLACE(Props, '\u0000', '') WHERE Props LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_recentsearches_query.sql
+++ b/queries/fixes/unicode/fix_recentsearches_query.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'RecentSearches'
-     AND table_schema = DATABASE()
-     AND column_name = 'Query'
- ) > 0,
- 'UPDATE RecentSearches SET Query = REPLACE(Query, \'\\\\u0000\', \'\') WHERE Query LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE RecentSearches SET Query = REPLACE(Query, '\u0000', '') WHERE Query LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_retentionidsfordeletion_ids.sql
+++ b/queries/fixes/unicode/fix_retentionidsfordeletion_ids.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'RetentionIdsForDeletion'
-     AND table_schema = DATABASE()
-     AND column_name = 'Ids'
- ) > 0,
- 'UPDATE RetentionIdsForDeletion SET Ids = REPLACE(Ids, \'\\\\u0000\', \'\') WHERE Ids LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE RetentionIdsForDeletion SET Ids = REPLACE(Ids, '\u0000', '') WHERE Ids LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_sessions_props.sql
+++ b/queries/fixes/unicode/fix_sessions_props.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Sessions'
-     AND table_schema = DATABASE()
-     AND column_name = 'Props'
- ) > 0,
- 'UPDATE Sessions SET Props = REPLACE(Props, \'\\\\u0000\', \'\') WHERE Props LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Sessions SET Props = REPLACE(Props, '\u0000', '') WHERE Props LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_threads_participants.sql
+++ b/queries/fixes/unicode/fix_threads_participants.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Threads'
-     AND table_schema = DATABASE()
-     AND column_name = 'Participants'
- ) > 0,
- 'UPDATE Threads SET Participants = REPLACE(Participants, \'\\\\u0000\', \'\') WHERE Participants LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Threads SET Participants = REPLACE(Participants, '\u0000', '') WHERE Participants LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_users_notifyprops.sql
+++ b/queries/fixes/unicode/fix_users_notifyprops.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Users'
-     AND table_schema = DATABASE()
-     AND column_name = 'NotifyProps'
- ) > 0,
- 'UPDATE Users SET NotifyProps = REPLACE(NotifyProps, \'\\\\u0000\', \'\') WHERE NotifyProps LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Users SET NotifyProps = REPLACE(NotifyProps, '\u0000', '') WHERE NotifyProps LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_users_props.sql
+++ b/queries/fixes/unicode/fix_users_props.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Users'
-     AND table_schema = DATABASE()
-     AND column_name = 'Props'
- ) > 0,
- 'UPDATE Users SET Props = REPLACE(Props, \'\\\\u0000\', \'\') WHERE Props LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Users SET Props = REPLACE(Props, '\u0000', '') WHERE Props LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_users_timezone.sql
+++ b/queries/fixes/unicode/fix_users_timezone.sql
@@ -1,14 +1,1 @@
-SET @preparedStatement = (SELECT IF(
- (
-     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-     WHERE table_name = 'Users'
-     AND table_schema = DATABASE()
-     AND column_name = 'Timezone'
- ) > 0,
- 'UPDATE Users SET Timezone = REPLACE(Timezone, \'\\\\u0000\', \'\') WHERE Timezone LIKE \'%\\u0000%\';',
- 'SELECT 1'
-));
-
-PREPARE updateIfExists FROM @preparedStatement;
-EXECUTE updateIfExists;
-DEALLOCATE PREPARE updateIfExists;
+UPDATE Users SET Timezone = REPLACE(Timezone, '\u0000', '') WHERE Timezone LIKE '%\u0000%';


### PR DESCRIPTION


#### Summary
While doing the check we already check if the table.column exists or not so we are not required to run that check again. This will simplify the query and also would avoid errors (happened to a user).

