### PR TITLE
[MM-60328] include proper search_path check to post-migrate

### DIFF
--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -63,9 +63,11 @@ func (db *DB) CheckPostgresDefaultSchema(ctx context.Context, schema string, log
 		}
 		schemas = append(schemas, s)
 	}
+	slices.Sort(schemas)
+
 	if len(schemas) == 0 {
 		return fmt.Errorf("no value available for search_path")
-	} else if _, ok := slices.BinarySearch(schemas, schema); !ok {
+	} else if _, ok := slices.BinarySearch(schemas, fmt.Sprintf("%q, %s", "$user", schema)); !ok {
 		logger.Printf("could not find the default schema %q in search_path, consider setting it from the postgresql console\n", schema)
 		err := db.ExecQuery(ctx, fmt.Sprintf("SELECT pg_catalog.set_config('search_path', '\"$user\", %s', false)", schema))
 		if err != nil {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -65,11 +65,12 @@ func (db *DB) CheckPostgresDefaultSchema(ctx context.Context, schema string, log
 	}
 	slices.Sort(schemas)
 
+	schemaSetting := fmt.Sprintf("%q, %s", "$user", schema)
 	if len(schemas) == 0 {
 		return fmt.Errorf("no value available for search_path")
-	} else if _, ok := slices.BinarySearch(schemas, fmt.Sprintf("%q, %s", "$user", schema)); !ok {
+	} else if _, ok := slices.BinarySearch(schemas, schemaSetting); !ok {
 		logger.Printf("could not find the default schema %q in search_path, consider setting it from the postgresql console\n", schema)
-		err := db.ExecQuery(ctx, fmt.Sprintf("SELECT pg_catalog.set_config('search_path', '\"$user\", %s', false)", schema))
+		err := db.ExecQuery(ctx, fmt.Sprintf("SELECT pg_catalog.set_config('search_path', '%s', false)", schemaSetting))
 		if err != nil {
 			return fmt.Errorf("could not set search_path for the session: %w", err)
 		}


### PR DESCRIPTION

#### Summary
After every migration, we should advise running `migration-assist post-migrate` command to determine the health of the DB in terms of schema and it's ownership.

Also make index creation optional. Will add documentation accordingly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60328
