### PR TITLE
fix backslash escape for unicode escape sequence

### DIFF
--- a/queries/fixes/unicode/fix_channelmembers_notifyprops.sql
+++ b/queries/fixes/unicode/fix_channelmembers_notifyprops.sql
@@ -1,1 +1,1 @@
-UPDATE ChannelMembers SET NotifyProps = REPLACE(NotifyProps, '\u0000', '') WHERE NotifyProps LIKE '%\u0000%';
+UPDATE ChannelMembers SET NotifyProps = REPLACE(NotifyProps, '\\u0000', '') WHERE NotifyProps LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_jobs_data.sql
+++ b/queries/fixes/unicode/fix_jobs_data.sql
@@ -1,1 +1,1 @@
-UPDATE Jobs SET Data = REPLACE(Data, '\u0000', '') WHERE Data LIKE '%\u0000%';
+UPDATE Jobs SET Data = REPLACE(Data, '\\u0000', '') WHERE Data LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_linkmetadata_data.sql
+++ b/queries/fixes/unicode/fix_linkmetadata_data.sql
@@ -1,1 +1,1 @@
-UPDATE LinkMetadata SET Data = REPLACE(Data, '\u0000', '') WHERE Data LIKE '%\u0000%';
+UPDATE LinkMetadata SET Data = REPLACE(Data, '\\u0000', '') WHERE Data LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_posts.props.sql
+++ b/queries/fixes/unicode/fix_posts.props.sql
@@ -1,1 +1,1 @@
-UPDATE Posts SET Props = REPLACE(Props, '\u0000', '') WHERE Props LIKE '%\u0000%';
+UPDATE Posts SET Props = REPLACE(Props, '\\u0000', '') WHERE Props LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_recentsearches_query.sql
+++ b/queries/fixes/unicode/fix_recentsearches_query.sql
@@ -1,1 +1,1 @@
-UPDATE RecentSearches SET Query = REPLACE(Query, '\u0000', '') WHERE Query LIKE '%\u0000%';
+UPDATE RecentSearches SET Query = REPLACE(Query, '\\u0000', '') WHERE Query LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_retentionidsfordeletion_ids.sql
+++ b/queries/fixes/unicode/fix_retentionidsfordeletion_ids.sql
@@ -1,1 +1,1 @@
-UPDATE RetentionIdsForDeletion SET Ids = REPLACE(Ids, '\u0000', '') WHERE Ids LIKE '%\u0000%';
+UPDATE RetentionIdsForDeletion SET Ids = REPLACE(Ids, '\\u0000', '') WHERE Ids LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_sessions_props.sql
+++ b/queries/fixes/unicode/fix_sessions_props.sql
@@ -1,1 +1,1 @@
-UPDATE Sessions SET Props = REPLACE(Props, '\u0000', '') WHERE Props LIKE '%\u0000%';
+UPDATE Sessions SET Props = REPLACE(Props, '\\u0000', '') WHERE Props LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_threads_participants.sql
+++ b/queries/fixes/unicode/fix_threads_participants.sql
@@ -1,1 +1,1 @@
-UPDATE Threads SET Participants = REPLACE(Participants, '\u0000', '') WHERE Participants LIKE '%\u0000%';
+UPDATE Threads SET Participants = REPLACE(Participants, '\\u0000', '') WHERE Participants LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_users_notifyprops.sql
+++ b/queries/fixes/unicode/fix_users_notifyprops.sql
@@ -1,1 +1,1 @@
-UPDATE Users SET NotifyProps = REPLACE(NotifyProps, '\u0000', '') WHERE NotifyProps LIKE '%\u0000%';
+UPDATE Users SET NotifyProps = REPLACE(NotifyProps, '\\u0000', '') WHERE NotifyProps LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_users_props.sql
+++ b/queries/fixes/unicode/fix_users_props.sql
@@ -1,1 +1,1 @@
-UPDATE Users SET Props = REPLACE(Props, '\u0000', '') WHERE Props LIKE '%\u0000%';
+UPDATE Users SET Props = REPLACE(Props, '\\u0000', '') WHERE Props LIKE '%\u0000%';

--- a/queries/fixes/unicode/fix_users_timezone.sql
+++ b/queries/fixes/unicode/fix_users_timezone.sql
@@ -1,1 +1,1 @@
-UPDATE Users SET Timezone = REPLACE(Timezone, '\u0000', '') WHERE Timezone LIKE '%\u0000%';
+UPDATE Users SET Timezone = REPLACE(Timezone, '\\u0000', '') WHERE Timezone LIKE '%\u0000%';


### PR DESCRIPTION

#### Summary
Figured out this by testing locally, we should actually escape the backslash because the replace reads values as raw strings.


