### PR TITLE
fix embed issue by pinning go toolchain

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -7,6 +9,7 @@ builds:
     id: "migration-assist"
     env:
       - CGO_ENABLED=0
+      - GOTOOLCHAIN=1.22.2
     ldflags:
       - -s -w -X github.com/mattermost/migration-assist/cmd/migration-assist/commands.Version={{.Version}}
     goos:
@@ -17,8 +20,7 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
-    name_template: >-
+   - name_template: >-
       {{ .ProjectName }}-{{- title .Os }}-{{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}


### PR DESCRIPTION

#### Summary
Seems like there is an issue with the compilation or something changed, embedded files are not getting embedded. The only way I could make it work was using the `1.22.2` toolchain. Do you have any thoughts on this @agarciamontoro?


