### PR TITLE
add --ping-only flag to mysql and postgres subcommands

### DIFF
--- a/cmd/migration-assist/commands/mysql.go
+++ b/cmd/migration-assist/commands/mysql.go
@@ -38,6 +38,7 @@ func SourceCheckCmd() *cobra.Command {
 	cmd.Flags().Bool("fix-unicode", false, "Removes the unsupported unicode characters from MySQL tables")
 	cmd.Flags().Bool("full-schema-check", false, "Checks the MySQL schema to determine whether it's in desired state")
 	cmd.Flags().Bool("save-diff", false, "Writes diffs to files")
+	cmd.Flags().Bool("ping-only", false, "Only verify connectivity to the MySQL server and exit without running checks")
 	cmd.Flags().String("migrations-dir", "", "Migrations directory (should be used if mattermost-version is not supplied)")
 	cmd.Flags().String("mattermost-version", "v9.7", "Mattermost version to be cloned to run migrations")
 	cmd.Flags().String("output", "mysql.output", "Output file for the applied migrations, postgres subcommands will use this file to apply the migrations")
@@ -68,6 +69,10 @@ func runSourceCheckCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not ping mysql: %w", err)
 	}
 	baseLogger.Println("connected to mysql successfully...")
+
+	if pingOnly, _ := cmd.Flags().GetBool("ping-only"); pingOnly {
+		return nil
+	}
 
 	applied, err := mysqlDB.GetAppliedMigrations(cmd.Context())
 	if err != nil {

--- a/cmd/migration-assist/commands/postgres.go
+++ b/cmd/migration-assist/commands/postgres.go
@@ -38,6 +38,7 @@ func TargetCheckCmd() *cobra.Command {
 	cmd.Flags().String("git", "git", "git binary to be executed if the repository will be cloned (ie. --mattermost-version is supplied)")
 	cmd.Flags().Bool("check-schema-owner", true, "Check if the schema owner is the same as the user running the migration")
 	cmd.Flags().Bool("check-tables-empty", true, "Check if tables are empty before running migrations")
+	cmd.Flags().Bool("ping-only", false, "Only verify connectivity to the Postgres server and exit without running checks")
 	cmd.PersistentFlags().String("schema", "public", "the default schema to be used for the session")
 
 	return cmd
@@ -80,6 +81,10 @@ func runTargetCheckCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not ping postgres: %w", err)
 	}
 	baseLogger.Println("connected to postgres successfully.")
+
+	if pingOnly, _ := cmd.Flags().GetBool("ping-only"); pingOnly {
+		return nil
+	}
 
 	var params pgloader.Parameters
 	err = pgloader.ParsePostgres(&params, args[0])


### PR DESCRIPTION
## Summary

- Adds a `--ping-only` flag to both `migration-assist mysql` and `migration-assist postgres`.
- When set, the command opens a connection, performs the existing `Ping()`, prints the existing "connected … successfully" line, and returns — skipping all schema checks, applied-migrations reads, and output-file writes.
- Useful for support workflows where the goal is to verify DSN / network / credential validity before committing to a full schema-readiness run.

## Test plan

Tested locally against `mysql:8.0` and `postgres:15` containers.

- [x] `migration-assist mysql <dsn> --ping-only` → exits 0 after the connect line, no `mysql.output` written, no further DB activity.
- [x] `migration-assist mysql <dsn>` (control, no flag) → proceeds to `GetAppliedMigrations` (fails on missing `db_migrations` table on a vanilla MySQL container, confirming the checks still run when the flag is absent).
- [x] `migration-assist postgres <dsn> --ping-only` → exits 0 after the connect line, schema-owner check skipped.
- [x] `migration-assist postgres <dsn>` (control, no flag) → proceeds to `CheckPostgresSchemaOwnership` (fails because `mmuser` doesn't own `public` in pg15, confirming the checks still run when the flag is absent).
- [x] `--help` on both subcommands shows the new flag.
- [x] `go build ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)