### PR TITLE
Fix duplicated `"$user"` and string-literal quoting in pgloader search_path

### DIFF
--- a/internal/pgloader/load_test.go
+++ b/internal/pgloader/load_test.go
@@ -1,7 +1,11 @@
 package pgloader
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
 	"testing"
+	"text/template"
 )
 
 func TestParseMySQL(t *testing.T) {
@@ -312,6 +316,68 @@ func TestParsePostgres(t *testing.T) {
 			}
 			if params.TargetSchema != tt.want.TargetSchema {
 				t.Errorf("ParsePostgres() TargetSchema = %v, want %v", params.TargetSchema, tt.want.TargetSchema)
+			}
+		})
+	}
+}
+
+// TestSearchPathTemplateRendering guards against regression of the
+// `search_path` interpolation defect where the AFTER LOAD DO block emitted
+// `'"$user", "$user", public'` (duplicate `"$user"`) and wrapped the
+// ALTER USER value in single quotes, producing a fragile string-literal
+// search_path that could not be parsed back into a valid identifier list.
+func TestSearchPathTemplateRendering(t *testing.T) {
+	templates := []string{"config", "boards", "playbooks", "calls"}
+
+	params := Parameters{
+		MySQLUser:     "mmuser",
+		MySQLPassword: "mmpass",
+		MySQLAddress:  "127.0.0.1:3306",
+		SourceSchema:  "mattermost",
+		PGUser:        "mmuser",
+		PGPassword:    "mmpass",
+		PGAddress:     "127.0.0.1:5432",
+		TargetSchema:  "mattermost",
+		SearchPath:    `"$user", public`,
+	}
+
+	for _, name := range templates {
+		t.Run(name, func(t *testing.T) {
+			body, err := assets.ReadFile(fmt.Sprintf("templates/%s.tmpl", name))
+			if err != nil {
+				t.Fatalf("could not read template %s: %v", name, err)
+			}
+
+			tmpl, err := template.New(name).Parse(string(body))
+			if err != nil {
+				t.Fatalf("could not parse template %s: %v", name, err)
+			}
+
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, params); err != nil {
+				t.Fatalf("could not execute template %s: %v", name, err)
+			}
+			got := buf.String()
+
+			if strings.Contains(got, `"$user", "$user"`) {
+				t.Errorf("template %s emitted a duplicated `\"$user\"` in the search_path; got:\n%s", name, got)
+			}
+
+			wantSetConfig := `set_config('search_path', '"$user", public', false)`
+			if !strings.Contains(got, wantSetConfig) {
+				t.Errorf("template %s missing expected set_config call %q; got:\n%s", name, wantSetConfig, got)
+			}
+
+			wantAlterUser := `ALTER USER mmuser SET search_path TO "$user", public;`
+			if !strings.Contains(got, wantAlterUser) {
+				t.Errorf("template %s missing expected ALTER USER statement %q; got:\n%s", name, wantAlterUser, got)
+			}
+
+			if strings.Contains(got, `SET search_path TO '"$user", public'`) ||
+				strings.Contains(got, `SET SEARCH_PATH TO '"$user", public'`) ||
+				strings.Contains(got, `SET search_path TO '$user, public'`) ||
+				strings.Contains(got, `SET SEARCH_PATH TO '$user, public'`) {
+				t.Errorf("template %s wrapped the ALTER USER search_path in a single-quoted string literal; got:\n%s", name, got)
 			}
 		})
 	}

--- a/internal/pgloader/templates/boards.tmpl
+++ b/internal/pgloader/templates/boards.tmpl
@@ -37,5 +37,5 @@ AFTER LOAD DO
     $$ UPDATE {{ .SourceSchema }}.focalboard_teams SET "settings" = '{}'::json WHERE "settings"::text = ''; $$,
     $$ UPDATE {{ .SourceSchema }}.focalboard_users SET "props" = '{}'::json WHERE "props"::text = ''; $$,
     $$ ALTER SCHEMA {{ .SourceSchema }} RENAME TO public; $$,
-    $$ SELECT pg_catalog.set_config('search_path', '"$user", {{ .SearchPath }}', false); $$,
-    $$ ALTER USER {{ .PGUser }} SET SEARCH_PATH TO '{{ .SearchPath }}'; $$;
+    $$ SELECT pg_catalog.set_config('search_path', '{{ .SearchPath }}', false); $$,
+    $$ ALTER USER {{ .PGUser }} SET search_path TO {{ .SearchPath }}; $$;

--- a/internal/pgloader/templates/calls.tmpl
+++ b/internal/pgloader/templates/calls.tmpl
@@ -25,5 +25,5 @@ BEFORE LOAD DO
 
 AFTER LOAD DO
     $$ ALTER SCHEMA {{ .SourceSchema }} RENAME TO public; $$,
-    $$ SELECT pg_catalog.set_config('search_path', '"$user", {{ .SearchPath }}', false); $$,
-    $$ ALTER USER {{ .PGUser }} SET SEARCH_PATH TO '{{ .SearchPath }}'; $$;
+    $$ SELECT pg_catalog.set_config('search_path', '{{ .SearchPath }}', false); $$,
+    $$ ALTER USER {{ .PGUser }} SET search_path TO {{ .SearchPath }}; $$;

--- a/internal/pgloader/templates/config.tmpl
+++ b/internal/pgloader/templates/config.tmpl
@@ -40,5 +40,5 @@ BEFORE LOAD DO
 AFTER LOAD DO
     $$ UPDATE {{ .SourceSchema }}.db_migrations set name='add_createat_to_teamembers' where version=92; $$,
     $$ ALTER SCHEMA {{ .SourceSchema }} RENAME TO public; $$,
-    $$ SELECT pg_catalog.set_config('search_path', '"$user", {{ .SearchPath }}', false); $$,
-    $$ ALTER USER {{ .PGUser }} SET SEARCH_PATH TO '{{ .SearchPath }}'; $$;
+    $$ SELECT pg_catalog.set_config('search_path', '{{ .SearchPath }}', false); $$,
+    $$ ALTER USER {{ .PGUser }} SET search_path TO {{ .SearchPath }}; $$;

--- a/internal/pgloader/templates/playbooks.tmpl
+++ b/internal/pgloader/templates/playbooks.tmpl
@@ -87,5 +87,5 @@ AFTER LOAD DO
     $$ CREATE INDEX IF NOT EXISTS ir_statusposts_incidentid_postid_key on {{ .SourceSchema }}.IR_StatusPosts(IncidentId,PostId); $$,
     $$ CREATE INDEX IF NOT EXISTS ir_playbookmember_playbookid on {{ .SourceSchema }}.IR_PlaybookMember(PlaybookId); $$,
     $$ ALTER SCHEMA {{ .SourceSchema }} RENAME TO public; $$,
-    $$ SELECT pg_catalog.set_config('search_path', '"$user", {{ .SearchPath }}', false); $$,
-    $$ ALTER USER {{ .PGUser }} SET SEARCH_PATH TO '{{ .SearchPath }}'; $$;
+    $$ SELECT pg_catalog.set_config('search_path', '{{ .SearchPath }}', false); $$,
+    $$ ALTER USER {{ .PGUser }} SET search_path TO {{ .SearchPath }}; $$;


### PR DESCRIPTION
## Summary

The pgloader templates emit a malformed `search_path` in the `AFTER LOAD DO` block, which leaves `mmuser`'s persistent `search_path` pointing at a non-existent schema after migration. Downstream symptom: `\dt` finds no tables and `migration-assist postgres post-migrate` fails with `could not find the default schema "public" in search_path`.

## Defect

The current `config.tmpl` (and the three product templates) end with:

```
$$ SELECT pg_catalog.set_config('search_path', '"$user", {{ .SearchPath }}', false); $$,
$$ ALTER USER {{ .PGUser }} SET SEARCH_PATH TO '{{ .SearchPath }}'; $$;
```

`internal/pgloader/load.go` populates `.SearchPath` from `SHOW SEARCH_PATH` against the target Postgres DB. On a default install this returns the literal string `"$user", public` — so two things go wrong:

1. **Duplicated `"$user"`** — the template hardcodes a `"$user", ` prefix on the `set_config` line and then appends `.SearchPath`, which already starts with `"$user", `. Output: `'"$user", "$user", public'`.

2. **String-literal `ALTER USER` value** — wrapping `.SearchPath` in single quotes produces string-literal GUC syntax instead of identifier-list syntax. Combined with quoting inconsistencies in the source value, this can persist a malformed `search_path` that PostgreSQL parses as a single schema name (e.g. `"$user, public"` — one identifier with a comma in the middle).

Bug introduced in commit d27e80f ("add ability correctly set search path", 2024-06-12), which added the template interpolations but kept the hardcoded `"$user", ` prefix from the previous template and re-introduced the single-quote wrapping.

## Fix

Round-trip whatever `SHOW search_path` returned, with no extra prefix and no string-literal wrapping. Same change applied to all four templates (`config.tmpl`, `boards.tmpl`, `playbooks.tmpl`, `calls.tmpl`):

```diff
-    $$ SELECT pg_catalog.set_config('search_path', '"$user", {{ .SearchPath }}', false); $$,
-    $$ ALTER USER {{ .PGUser }} SET SEARCH_PATH TO '{{ .SearchPath }}'; $$;
+    $$ SELECT pg_catalog.set_config('search_path', '{{ .SearchPath }}', false); $$,
+    $$ ALTER USER {{ .PGUser }} SET search_path TO {{ .SearchPath }}; $$;
```

After the fix, with `.SearchPath = "$user", public`:

```
$$ SELECT pg_catalog.set_config('search_path', '"$user", public', false); $$,
$$ ALTER USER mmuser SET search_path TO "$user", public; $$;
```

…which is exactly what `initdb` produces by default.

## Test

Adds `TestSearchPathTemplateRendering` in `internal/pgloader/load_test.go`. It loads each of the four templates from the embedded FS, renders them with `.SearchPath = "\"$user\", public"`, and asserts:

- No `"$user", "$user"` substring (no duplication).
- The `set_config` line emits `'"$user", public'` exactly once.
- The `ALTER USER` line uses identifier syntax (`SET search_path TO "$user", public;`), not string-literal syntax.

Verified the test fails against the unfixed templates and passes after the fix.

## Related issues

These all report the downstream symptom (post-migrate failure or mangled `search_path`) and are root-caused by this defect:

- #37 — `migration-assist: postgres post-migrate gives "could not find the default schema "public" in search_path"`
- #44 — `Multiple issues with migration-assist and pgloader` (post-migrate "could not find the default schema 'public'")
- #50 — `the command fails to generate correct config with single quotes for DSN` (mangled `SHOW search_path` output)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (new test included)
- [x] Verified test catches the regression (fails against pre-fix templates)
- [ ] Manual verification with a real MySQL → Postgres migration in a reviewer's environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)